### PR TITLE
fix: Fix value is unavailable build error

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -38,6 +38,13 @@ target 'faceReactNativeSampleDapp' do
       # necessary for Mac Catalyst builds
       :mac_catalyst_enabled => false
     )
+    # NOTE: Change IPHONEOS_DEPLOYMENT_TARGET to 12.4.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.4'
+      end
+    end
+
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end


### PR DESCRIPTION
I encountered `'value' is unavailable: introduced in iOS 12.0` while building the iOS app.
It seems that some cocoa pods are using iOS 12.0's feature.

I couldn't find a normal solution for this problem.
So I tried an ad hoc solution, and it worked.

I find it at https://github.com/facebook/react-native/issues/34106#issuecomment-1417685116